### PR TITLE
This is the correct path (on OpenFire and ejabberd) to the auth mechanisms

### DIFF
--- a/lib/XmppBosh.php
+++ b/lib/XmppBosh.php
@@ -93,7 +93,7 @@ class XmppBosh {
         $response = $this->sendInitConnection();
         $body = self::getBodyFromXml($response);
         $this->sid = $body->getAttribute('sid');
-        $mechanisms = $body->firstChild->firstChild->getElementsByTagName('mechanism');
+        $mechanisms = $body->firstChild->getElementsByTagName('mechanism');
 
         foreach ($mechanisms as $value) {
             $this->mechanisms[] = $value->nodeValue;


### PR DESCRIPTION
This change was required in order to make the library work with OpenFire and ejabberd.